### PR TITLE
Use PSR-1 for PHPUnit TestCase

### DIFF
--- a/tests/PhpMailerTest.php
+++ b/tests/PhpMailerTest.php
@@ -12,7 +12,9 @@
 
 namespace Apix\Log\Logger;
 
-class PhpMailerTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class PhpMailerTest extends TestCase
 {
 
     protected $mailer;
@@ -58,7 +60,7 @@ class PhpMailerTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException Psr\Log\InvalidArgumentException
-     * @expectedExceptionMessage No valid email address set in \PHPMailer
+     * @expectedExceptionMessage No valid email address set in PHPMailer
      */
     public function testThrowsInvalidArgumentExceptionWhenNoValidEmail()
     {


### PR DESCRIPTION
Use [PSR-1](http://www.php-fig.org/psr/psr-1/#namespace-and-class-names) while extending PHPUnit TestCase class. This will help us when to migrate to PHPUnit 6, that [no longer support snake case namespaces](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).